### PR TITLE
Improve feed performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@
 /config/database.yml
 .DS_Store
 /storage/*
+
+.idea/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.order(played_at: :desc, id: :desc).includes(:user)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: https://github.com/GeorgeMarcus/golfr_backend/issues/1

**Changes**

The `user_feed` method now uses eager loading instead of lazy loading when fetching the users associated with each score.

**Before**

<img width="937" alt="Screenshot 2021-12-22 at 14 03 39" src="https://user-images.githubusercontent.com/93763306/147094637-c8f2afa4-8f96-488d-9c7a-b25384803ac5.png">

**After**

<img width="975" alt="Screenshot 2021-12-22 at 14 04 48" src="https://user-images.githubusercontent.com/93763306/147094668-a5b839ef-1d5f-4002-9594-d4e8439e33dc.png">
